### PR TITLE
Add es6-promise to Karma configuration if using Vuex

### DIFF
--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -14,7 +14,10 @@ module.exports = function (config) {
     browsers: ['PhantomJS'],
     frameworks: ['mocha', 'sinon-chai', 'phantomjs-shim'],
     reporters: ['spec', 'coverage'],
-    files: ['./index.js'],
+    files: [{{#vuex}}
+      '../../node_modules/es6-promise/dist/es6-promise.auto.js',
+      {{/vuex}}'./index.js'{{#vuex}}
+    {{/vuex}}],
     preprocessors: {
       './index.js': ['webpack', 'sourcemap']
     },


### PR DESCRIPTION
Vuex requires the ES6 promise polyfill in the PhantomJS browser.